### PR TITLE
CircleCI config refactoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,33 +1,41 @@
 version: 2
 jobs:
-   build:
-     docker:
-       - image: circleci/node:9.11.1
-     steps:
-      - checkout
-      - restore_cache:
-          name: Restore Yarn Package Cache
-          keys:
-            - yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - yarn-packages-{{ .Branch }}
-            - yarn-packages-master
-            - yarn-packages-
-      - run:
-          name: Install Dependencies
-          command: yarn install
-      - save_cache:
-          name: Save Yarn Package Cache
-          key: yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules/
-      - run:
-          name: build
-          command: yarn build
-      - store_artifacts:
-          path: coverage
-          prefix: coverage
-      - store_test_results:
-          path: ./junit
-      - store_artifacts:
-          path: ./junit          
-
+    build:
+        docker:
+            - image: circleci/node:9.11.1
+        steps:
+            - checkout
+            - restore_cache:
+                name: Restore Yarn Package Cache
+                keys:
+                    - yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
+                    - yarn-packages-{{ .Branch }}
+                    - yarn-packages-master
+                    - yarn-packages-
+            - run:
+                name: Install Dependencies
+                command: yarn install
+            - save_cache:
+                name: Save Yarn Package Cache
+                key: yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
+                paths:
+                    - node_modules/
+            - run:
+                name: Run Static Analysis Test
+                command: yarn lint
+            - run:
+                name: Run Unit Tests and Build
+                command: yarn build
+            - store_test_results:
+                path: ./build/reports/test
+            - store_artifacts:
+                path: ./build/reports/coverage
+                destination: coverage-report
+            - store_artifacts:
+                path: ./build/reports/test
+                destination: unit-test-report
+workflows:
+    version: 2
+    test_and_build:
+        jobs:
+            - build  

--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,5 @@ typings/
 # build folder
 dist
 
-# junit mocha test results
-junit/
+# unit test and coverage reports
+build

--- a/.nycrc
+++ b/.nycrc
@@ -24,5 +24,7 @@
     "branches": [99, 100],
     "functions": [99, 100],
     "statements": [99, 100]
-  }
+  },
+  "report-dir": "./build/reports/coverage",
+  "temp-directory": "./build/tmp/.nyc_output"
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "author": "jonathan.philip.stevens@gmail.com",
   "license": "MIT",
   "scripts": {
-    "test": "NODE_ENV=test MOCHA_FILE=./junit/test-results.xml nyc mocha --reporter mocha-junit-reporter",
+    "lint": "eslint --ignore-path .gitignore --ignore-pattern \"!**/.*\" .",
+    "test": "NODE_ENV=test MOCHA_FILE=./build/reports/test/junit.xml nyc mocha --reporter mocha-junit-reporter",
     "compile": "babel src --out-dir dist --source-maps inline",
     "prebuild": "npm run test",
     "build": "npm run compile"

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 import { getDisplayString } from "./render";
 
-console.log(getDisplayString());
+console.log(getDisplayString()); // eslint-disable-line no-console


### PR DESCRIPTION
- Keep Unit test and Coverage reports inside the `build/reports` directory
- Output `.nyc_output` under `build/tmp` directory
- Add ESLint test in npm script and CI job